### PR TITLE
standards_lab: rework project sessions and rework project "forking"

### DIFF
--- a/standards_lab/api/urls.py
+++ b/standards_lab/api/urls.py
@@ -6,8 +6,7 @@ import api.views as views
 app_name = ApiConfig.name
 
 urlpatterns = [
-    path("project/", views.ProjectStatus.as_view(), name="project"),
-    path("project/<slug:name>", views.ProjectStatus.as_view(), name="project-details"),
+    path("project/<slug:name>", views.ProjectConfig.as_view(), name="project-config"),
     path(
         "project/<slug:name>/upload",
         views.ProjectUploadFile.as_view(),

--- a/standards_lab/ui/templates/home.html
+++ b/standards_lab/ui/templates/home.html
@@ -17,10 +17,11 @@
 
   <div class="form-group">
     <label for="new-project" class="mr-3">Project name</label>
-    <input type="text" id="new-project" placeholder="project name" required>
-    <div class="input-group-append">
-      <button class="btn btn-primary" onclick='window.location.href="{% url "ui:project" "__new__" %}?new=true".replace("__new__", $("#new-project").val())'>Create</button>
-    </div>
+    <input type="text" id="new-project" class="form-control" placeholder="project name" required>
+    <small>Accepted characters are A-Z, a-z, 0-9 , - and _ </small>
+  </div>
+  <div class="form-group">
+    <button class="btn btn-primary" onclick='window.location.href="{% url "ui:project" "__new__" %}?new=true".replace("__new__", $("#new-project").val())'>Create</button>
   </div>
 
 </div>

--- a/standards_lab/ui/templates/project.html
+++ b/standards_lab/ui/templates/project.html
@@ -10,7 +10,6 @@
 </main>
 {#  end of page  #}
 
-
 {# Vue Application 'standards-lab' #}
 {% verbatim %}
 
@@ -20,16 +19,18 @@
 
   <div class="row border mb-3">
     <div class="col">
+      <p>Own this project: {{ownThisProject}}</p>
       <div class="form-group">
         <label for="project-name-input">Project Name</label>
-        <input type="text" id="project-name-input" class="form-control form-control-lg" style="width: 100%" v-model="project.name" >
+        <input type="text" id="project-name-input" class="form-control form-control-lg" style="width: 100%" v-model="project.name"  >
+        <small>Accepted characters are A-Z, a-z, 0-9 , - and _ </small>
       </div>
-      <div class="form-group">
-        <input type="checkbox" name="editable" id="project-editable" v-model="project.editable" checked="checked">
+      <div class="form-group" v-if="ownThisProject">
+        <input type="checkbox" name="editable" id="project-editable" v-model="project.editable" >
         <label for="project-editable">Editable by anyone with the link</label>
       </div>
       <div class="form-group">
-        <input type="btn" class="btn btn-primary" value="Save" v-on:click="updateProjectProperties">
+        <button class="btn btn-primary" v-on:click="updateProjectProperties">{{saveLabel}}</button>
       </div>
     </div>
   </div>
@@ -85,11 +86,15 @@
 </div>
 </script>
 {% endverbatim %}
-
 <script>
-  var projectApiUrl = "{% url 'api:project' %}";
+  var projectApiUrl = "{% url "api:project-config" view.kwargs.project_name %}";
   var csrfmiddlewaretoken_value = "{{ csrf_token }}";
   var initialProject = undefined;
+  var ownThisProject = false;
+
+  {% if view.kwargs.project_name in request.session.projects_owned %}
+  ownThisProject = true;
+  {% endif %}
 
   initialProject = {{project|safe}};
 </script>
@@ -102,27 +107,50 @@
       return {
         project: { name: undefined, schemaFiles:undefined, dataFiles: undefined  },
         spinner: undefined,
+        saveLabel: "Save",
       }
     },
 
     created: function(){
-      this.project = initialProject;
+      this.project = Object.assign({}, initialProject);
+      this.ownThisProject = ownThisProject;
+    },
+
+    watch: {
+      "project.name": function(){
+        console.log(this.project.name);
+        if (this.project.name != initialProject.name){
+          this.saveLabel = "Save New Version";
+        } else {
+          this.saveLabel = "Save";
+        }
+      },
+
     },
 
     methods: {
       /* Update any of the project's properties */
       updateProjectProperties: function(){
 
-        if (window.location.href.indexOf(this.project.name) === -1){
-          const url = new URL(window.location);
-          window.history.pushState({}, this.project.name, url.origin + '/p/' + this.project.name);
-        }
+        console.log(this.project);
 
-        fetch(projectApiUrl + this.project.name, {
+        fetch(projectApiUrl, {
           method:'POST',
           credentials: 'same-origin',
           headers: { 'X-CSRFToken': csrfmiddlewaretoken_value },
-          body: JSON.stringify({ "name": this.project.name }),
+          body: JSON.stringify(this.project),
+        }).then(response => response.json()).then(result => {
+          if (result.error == undefined){
+            this.project = result;
+
+            /* If we have changed project name for simplicity we reload the page to the new project page */
+            if (window.location.href.indexOf(this.project.name) === -1){
+              const url = new URL(window.location);
+              window.location.href = url.origin + '/p/' + this.project.name;
+            }
+          } else {
+            alert(result.error);
+          }
         });
       },
 
@@ -138,16 +166,20 @@
         fd.append("file", file);
         fd.append("uploadType", uploadType);
 
-        fetch(projectApiUrl + this.project.name + '/upload', {
+        fetch(projectApiUrl + '/upload', {
           method:'POST',
           credentials: 'same-origin',
           headers: {
             'X-CSRFToken': csrfmiddlewaretoken_value,
           },
           body: fd,
-        }).then(response => response.json()).then(data => {
-          ctx.spinner = undefined;
-          ctx.project = data;
+        }).then(response => response.json()).then(result => {
+          if (result.error == undefined){
+            this.project = result;
+            this.spinner = undefined;
+          } else {
+            alert(result.error)
+          }
         });
 
       },

--- a/standards_lab/utils/project.py
+++ b/standards_lab/utils/project.py
@@ -3,20 +3,24 @@ import os
 import json
 
 
-def get_project_config(project_name):
+def get_project_config(project_name, json_format=False):
+    """ Returns the specified project config, optionally in json format """
     with open(
         os.path.join(settings.ROOT_PROJECTS_DIR, project_name, "settings.json")
     ) as fp:
+        if json_format:
+            return fp.read()
+
         return json.load(fp)
 
 
-def create_new_project(project_name):
-    """ Create new project or return config for existing project """
+def create_new_project(project_name, json_format=False):
+    """ Create new project or return config for existing project optionally in json format """
 
     path = os.path.join(settings.ROOT_PROJECTS_DIR, project_name)
 
     if os.path.exists(path):
-        return get_project_config(project_name)
+        return False, get_project_config(project_name, json_format=json_format)
 
     os.makedirs(path)
 
@@ -27,4 +31,7 @@ def create_new_project(project_name):
     ) as fp:
         json.dump(project, fp)
 
-    return project
+    if json_format:
+        return True, json.dumps(project)
+
+    return True, project


### PR DESCRIPTION
- Remove caching of project config in user session, doing this prevents
easy sharing of state. For now we will read and write to the project's
settings file.
- Store whether the session user is the creator of the project
- When saving the project, if the project name has changed create a new
version of the project by copying it. This is available regardless as to
whether you created the project or not
- Fix a couple of layout issues