### PR TITLE
processor.cove: Extend jsonschema validation with our own functions

### DIFF
--- a/standards_lab/processor/cove.py
+++ b/standards_lab/processor/cove.py
@@ -2,6 +2,7 @@ from libcove.lib.common import (
     common_checks_context,
     get_additional_codelist_values,
     SchemaJsonMixin,
+    validator,
 )
 
 from decimal import Decimal
@@ -13,6 +14,11 @@ import tempfile
 import django_rq
 from rq.job import Job
 from rq.exceptions import NoSuchJobError
+
+from .extra_validator_funcs import patch_validator
+
+
+patch_validator(validator)
 
 
 def start(project):

--- a/standards_lab/processor/extra_validator_funcs.py
+++ b/standards_lab/processor/extra_validator_funcs.py
@@ -1,0 +1,14 @@
+from jsonschema.exceptions import ValidationError
+
+
+def startswith(validator, schema_value, instance, schema_parent_value):
+    if not isinstance(instance, str):
+        return
+    if not instance.startswith(schema_value):
+        yield ValidationError("Should start with '{}'".format(schema_value))
+
+
+def patch_validator(validator):
+    validator.VALIDATORS.update({
+        "startswith": startswith
+    })


### PR DESCRIPTION
https://github.com/OpenDataServices/standards-lab/issues/26

Example:
Schema:
![Screenshot from 2021-02-25 15-28-45](https://user-images.githubusercontent.com/634/109176017-490b6400-777e-11eb-96ee-924f9c9dcba8.png)

API process endpoint:
![Screenshot from 2021-02-25 15-29-12](https://user-images.githubusercontent.com/634/109176008-4577dd00-777e-11eb-82ac-f3bb52f04578.png)
