### PR TITLE
extra_validator_funcs: Run black, add comment to force multi-line dict

### DIFF
--- a/standards_lab/processor/extra_validator_funcs.py
+++ b/standards_lab/processor/extra_validator_funcs.py
@@ -9,6 +9,9 @@ def startswith(validator, schema_value, instance, schema_parent_value):
 
 
 def patch_validator(validator):
-    validator.VALIDATORS.update({
-        "startswith": startswith
-    })
+    validator.VALIDATORS.update(
+        {
+            # Add validator functions above, and to this dict here
+            "startswith": startswith
+        }
+    )


### PR DESCRIPTION
Lint test broke on main, because we don't require rebasing on / merging in main.