### PR TITLE
README: Use port 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ docker-compose build
 docker-compose up
 ```
 
-Visit `localhost:8001` in a browser.
+Visit `localhost:8000` in a browser.
 
 [See developer docs for more information](docs/developer/)


### PR DESCRIPTION
I changed this in docker-compose.yml, but forgot to change it here. Port 8000 is more in line with what people expect.