### PR TITLE
processor: cove: rootListPath maybe unspecified

### DIFF
--- a/standards_lab/processor/cove.py
+++ b/standards_lab/processor/cove.py
@@ -47,7 +47,7 @@ def lib_cove_wrapper(
     """
 
     schema_name = project["rootSchema"]
-    root_list_path = project["rootListPath"]
+    root_list_path = project.get("rootListPath", "")
 
     schema_obj = SchemaJsonMixin()
 


### PR DESCRIPTION
This value isn't required so avoid a KeyError if it hasn't been set.