### PR TITLE
processor.cove: Increase redis `result_ttl` to 2 hours

### DIFF
--- a/standards_lab/processor/cove.py
+++ b/standards_lab/processor/cove.py
@@ -168,6 +168,7 @@ def start(project):
             project,
             data_file,
             job_id=job_id,
+            result_ttl=2 * 60 * 60,
         )
         output[data_file] = {"status": "SUCCESS"}
     return output


### PR DESCRIPTION
This ensures the results page can be viewed for this long.

https://github.com/OpenDataServices/standards-lab/issues/23