### PR TITLE
docs,templates: Remove mention of .xls, we don't support it

### DIFF
--- a/docs/user/project.md
+++ b/docs/user/project.md
@@ -93,7 +93,7 @@ Changes in the editor are only saved once the "Save Schema" button is pressed.
 
 Edit a new file by setting the file name using the "File open" text entry. This is set to "untitled.json" by default.
 
-Edit existing files use the Upload data button. Supported formats: Comma-Separated Values (.csv), JSON (.json), Microsoft Excel (.xls and .xlsx) or Open spreadsheet format (.ods).
+Edit existing files use the Upload data button. Supported formats: Comma-Separated Values (.csv), JSON (.json), Microsoft Excel (.xlsx) or Open spreadsheet format (.ods).
 
 Editing is supported for JSON files and CSV files.
 

--- a/standards_lab/ui/templates/project.html
+++ b/standards_lab/ui/templates/project.html
@@ -110,7 +110,7 @@
     </button>
     <div class="card-body">
       <h2 class="card-title">Data</h2>
-      <p>Upload data for testing. Supported formats: Comma-Separated Values (<code>.csv</code>), JSON (<code>.json</code>), Microsoft Excel (<code>.xls</code> and <code>.xlsx</code>) or Open spreadsheet format (<code>.ods</code>). Editing is supported for CSV and JSON files after uploading. <i><a href="https://standards-lab.readthedocs.io/en/latest/user/project.html#data" target="_blank">Project Data documentation.</a></i></p>
+      <p>Upload data for testing. Supported formats: Comma-Separated Values (<code>.csv</code>), JSON (<code>.json</code>), Microsoft Excel (<code>.xlsx</code>) or Open spreadsheet format (<code>.ods</code>). Editing is supported for CSV and JSON files after uploading. <i><a href="https://standards-lab.readthedocs.io/en/latest/user/project.html#data" target="_blank">Project Data documentation.</a></i></p>
 
       <div class="row">
 


### PR DESCRIPTION
The only Excel files we support are .xlsx