### PR TITLE
Make dev environment clearer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN sh -c 'cd standards_lab && python manage.py collectstatic'
 CMD sh -c ' \
     mkdir -p "$ROOT_PROJECTS_DIR" && \
     cd standards_lab && \
-    gunicorn --bind 0.0.0.0:80 wsgi:application \
+    gunicorn --bind 0.0.0.0:80 wsgi:application --reload \
     '
 EXPOSE 80

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,15 @@
+version: "3.5"
+
+services:
+
+  standards-lab-web:
+    environment:
+      DEBUG: 'True'
+    volumes:
+      - "./:/code"
+
+  standards-lab-worker:
+    environment:
+      DEBUG: 'True'
+    volumes:
+      - "./:/code"

--- a/docs/developer/docker.md
+++ b/docs/developer/docker.md
@@ -20,6 +20,6 @@ $ docker-compose up # (to restart)
 
 You'll need to rebuild the docker environment if you [add, remove, or upgrade the dependencies](dependencies.md).
 
-Restart the containers when you edit Python code for the changes to take effect (`docker-compose down` and `docker-compose up`).
+You don't need to rebuild or restart the containers when you edit any Python code. The changes will be detected and the server restarts automatically. 
 
 Read about [how to run the tests locally with docker](tests.md).

--- a/docs/developer/docker.md
+++ b/docs/developer/docker.md
@@ -1,0 +1,25 @@
+# Development and the docker environment
+
+We use docker and dokku in production, and docker-compose can be used as a local development environment.
+
+Start everything up with `docker-compose up`. This will show you logs from all of the running containers in the console. To run it in the background, use `docker-compose up -d`. Shut it down with `docker-compose down`.
+
+To see the logs (eg. in another console, or if you're running it in the background), run `docker-compose logs`. To see logs for a particular container, run `docker-compose logs [containter]`, eg. `docker-compose logs redis` (with the service names from the `docker-compose` file). Use the `docker-compose logs -f` to continually show the logs as the service runs.
+
+## Updating the Dockerfile
+
+If you make changes to either `Dockerfile` or `docker-compose.yml` you'll need to rebuild it locally to test it:
+
+```
+$ docker-compose down # (if running)
+$ docker-compose build --no-cache
+$ docker-compose up # (to restart)
+```
+
+## Updating the code
+
+You'll need to rebuild the docker environment if you [add, remove, or upgrade the dependencies](dependencies.md).
+
+You don't need to rebuild or restart the containers when you edit any Python code. The changes will be detected and the server restarts automatically. 
+
+Read about [how to run the tests locally with docker](tests.md).

--- a/docs/developer/docker.md
+++ b/docs/developer/docker.md
@@ -20,6 +20,6 @@ $ docker-compose up # (to restart)
 
 You'll need to rebuild the docker environment if you [add, remove, or upgrade the dependencies](dependencies.md).
 
-You don't need to rebuild or restart the containers when you edit any Python code. The changes will be detected and the server restarts automatically. 
+Restart the containers when you edit Python code for the changes to take effect (`docker-compose down` and `docker-compose up`).
 
 Read about [how to run the tests locally with docker](tests.md).


### PR DESCRIPTION
Adds a `docker-compose.override.yml` which separates out the explicit dev environment stuff. Also adds `--reload` to the Dockerfile so the server reloads automatically on code changes. I understand this is overridden by the Procfile for production deployment on dokku so shouldn't affect it.